### PR TITLE
Removed names on contact page

### DIFF
--- a/views/contact.ejs
+++ b/views/contact.ejs
@@ -44,7 +44,7 @@ function vistPage_Support(){
             <div class="item3" class="tile">
                 <div class="card">
                     <img src="/Images/pascal-bourque-G4mGWk-eHEM-unsplash.jpg" alt="img" style="width:100%">
-                    <h1>Julie Sutton</h1>
+                    <h1>Name</h1>
                     <p class="title">Counsellor</p>
                     <p>Mon - Thurs</p>
                     <div style="margin: 24px 0;">
@@ -59,7 +59,7 @@ function vistPage_Support(){
             <div class="item4" class="tile">
                 <div class="card">
                     <img src="/Images/pascal-bourque-G4mGWk-eHEM-unsplash.jpg" alt="img" style="width:100%">
-                    <h1>Raewyn Higgins</h1>
+                    <h1>Name</h1>
                     <p class="title">Counsellor</p>
                     <p>Tues - Fri</p>
                     <div style="margin: 24px 0;">
@@ -77,7 +77,7 @@ function vistPage_Support(){
             <div class="item5">
                 <div class="card">
                     <img src="/Images/pascal-bourque-G4mGWk-eHEM-unsplash.jpg" alt="img" style="width:100%">
-                    <h1>David Peek</h1>
+                    <h1>Name</h1>
                     <p class="title">Counsellor</p>
                     <p>(availability)</p>
                     <div style="margin: 24px 0;">


### PR DESCRIPTION
To remove the names of the councillors from the public website until we have the all-clear to display them.